### PR TITLE
Output cartesian coordinates instead of lon/lat

### DIFF
--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -38,64 +38,7 @@ function readTag(pbf, feature) {
 
 VectorTileFeature.types = ['Unknown', 'Point', 'LineString', 'Polygon'];
 
-VectorTileFeature.prototype.getFlatGeometryAndHoles = function(indexX, indexY) {
-    var pbf = this._pbf;
-    pbf.pos = this._geometry;
-
-    var tileX = this.extent * indexX,
-        tileY = this.extent * indexY;
-
-    var end = pbf.readVarint() + pbf.pos,
-        cmd = 1,
-        length = 0,
-        x = 0,
-        y = 0,
-        ringFirstPosition = [],
-        positions = [],
-        holeIndices = [];
-
-    while (pbf.pos < end) {
-        if (length <= 0) {
-            var cmdLen = pbf.readVarint();
-            cmd = cmdLen & 0x7;
-            length = cmdLen >> 3;
-        }
-
-        length--;
-
-        if (cmd === 1 || cmd === 2) {
-            x += pbf.readSVarint();
-            y += pbf.readSVarint();
-
-            if (cmd === 1) { // moveTo
-                // Starting or new hole
-                // if (line) lines.push(line);
-                // line = [];
-                ringFirstPosition = [x + tileX, y + tileY];
-            }
-
-            positions.push(x + tileX);
-            positions.push(y + tileY);
-
-        } else if (cmd === 7) {
-            positions.push(ringFirstPosition[0]); // closePolygon
-            positions.push(ringFirstPosition[1]); // closePolygon
-            holeIndices.push(positions.length);
-        } else {
-            throw new Error('unknown command ' + cmd);
-        }
-    }
-
-    holeIndices.pop();
-
-    // return lines;
-    return {
-        positions: positions,
-        holeIndices: holeIndices
-    };
-};
-
-VectorTileFeature.prototype.loadGeometry = function() {
+VectorTileFeature.prototype.loadGeometry = function(transformFunction) {
     var pbf = this._pbf;
     pbf.pos = this._geometry;
 
@@ -124,14 +67,14 @@ VectorTileFeature.prototype.loadGeometry = function() {
                 if (line) lines.push(line);
                 line = [];
             }
-
-            line.push(new Point(x, y));
+            line.push(transformFunction(x, y));
 
         } else if (cmd === 7) {
 
             // Workaround for https://github.com/mapbox/mapnik-vector-tile/issues/90
             if (line) {
-                line.push(line[0].clone()); // closePolygon
+                var firstLine = line[0].clone ? line[0].clone() : line[0].slice();
+                line.push(firstLine); // closePolygon
             }
 
         } else {
@@ -183,26 +126,16 @@ VectorTileFeature.prototype.bbox = function() {
     return [x1, y1, x2, y2];
 };
 
-VectorTileFeature.prototype.toUnprojectedJSON = function(x, y) {
-    var type = VectorTileFeature.types[this.type];
-
-    var geometry = this.getFlatGeometryAndHoles(x, y);
-
-    var geometryValue = { type: type };
-    Object.assign(geometryValue, geometry);
-
-    return {
-        type: "Feature",
-        geometry: geometryValue,
-        properties: this.properties
-    }
-};
 
 VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
+    var transformFunction = function (x, y) {
+        return new Point(x, y);
+    };
+
     var size = this.extent * Math.pow(2, z),
         x0 = this.extent * x,
         y0 = this.extent * y,
-        coords = this.loadGeometry(),
+        coords = this.loadGeometry(transformFunction),
         type = VectorTileFeature.types[this.type],
         i, j;
 
@@ -262,6 +195,57 @@ VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
     }
 
     return result;
+};
+
+VectorTileFeature.prototype.toOffsetsJSON = function() {
+    // Resize tiles to 512x512 bounding box
+    var tileSize = 512;
+    var tileExtent = this.extent;
+    var transformFunction = function (x, y) {
+        return [
+            (x/tileExtent) * tileSize,
+            (y/tileExtent) * tileSize
+        ];
+    };
+
+    var type = VectorTileFeature.types[this.type];
+    var geometryOffsets = this.loadGeometry(transformFunction);
+    var i;
+
+    switch (this.type) {
+        case 1:
+            var points = [];
+            for (i = 0; i < geometryOffsets.length; i++) {
+                points[i] = geometryOffsets[i][0];
+            }
+            geometryOffsets = points;
+            break;
+
+        case 3:
+            geometryOffsets = classifyRings(geometryOffsets);
+            break;
+    }
+
+    if (geometryOffsets.length === 1) {
+        geometryOffsets = geometryOffsets[0];
+    } else {
+        type = 'Multi' + type;
+    }
+
+    var jsonFeature = {
+        type: "Feature",
+        properties: this.properties,
+        geometry: {
+            type: type,
+            coordinates: geometryOffsets
+        }
+    };
+
+    if ('id' in this) {
+        jsonFeature.id = this.id;
+    }
+
+    return jsonFeature;
 };
 
 // classifies an array of rings into polygons with outer rings and holes

--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -38,6 +38,63 @@ function readTag(pbf, feature) {
 
 VectorTileFeature.types = ['Unknown', 'Point', 'LineString', 'Polygon'];
 
+VectorTileFeature.prototype.getFlatGeometryAndHoles = function(indexX, indexY) {
+    var pbf = this._pbf;
+    pbf.pos = this._geometry;
+
+    var tileX = this.extent * indexX,
+        tileY = this.extent * indexY;
+
+    var end = pbf.readVarint() + pbf.pos,
+        cmd = 1,
+        length = 0,
+        x = 0,
+        y = 0,
+        ringFirstPosition = [],
+        positions = [],
+        holeIndices = [];
+
+    while (pbf.pos < end) {
+        if (length <= 0) {
+            var cmdLen = pbf.readVarint();
+            cmd = cmdLen & 0x7;
+            length = cmdLen >> 3;
+        }
+
+        length--;
+
+        if (cmd === 1 || cmd === 2) {
+            x += pbf.readSVarint();
+            y += pbf.readSVarint();
+
+            if (cmd === 1) { // moveTo
+                // Starting or new hole
+                // if (line) lines.push(line);
+                // line = [];
+                ringFirstPosition = [x + tileX, y + tileY];
+            }
+
+            positions.push(x + tileX);
+            positions.push(y + tileY);
+
+        } else if (cmd === 7) {
+            positions.push(ringFirstPosition[0]); // closePolygon
+            positions.push(ringFirstPosition[1]); // closePolygon
+            holeIndices.push(positions.length);
+        } else {
+            throw new Error('unknown command ' + cmd);
+        }
+    }
+
+    holeIndices.pop();
+
+    // return lines;
+    return {
+        positions: positions,
+        holeIndices: holeIndices
+    };
+};
+
 VectorTileFeature.prototype.loadGeometry = function() {
     var pbf = this._pbf;
     pbf.pos = this._geometry;
@@ -124,6 +181,21 @@ VectorTileFeature.prototype.bbox = function() {
     }
 
     return [x1, y1, x2, y2];
+};
+
+VectorTileFeature.prototype.toUnprojectedJSON = function(x, y) {
+    var type = VectorTileFeature.types[this.type];
+
+    var geometry = this.getFlatGeometryAndHoles(x, y);
+
+    var geometryValue = { type: type };
+    Object.assign(geometryValue, geometry);
+
+    return {
+        type: "Feature",
+        geometry: geometryValue,
+        properties: this.properties
+    }
 };
 
 VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {


### PR DESCRIPTION
I’m trying to use CARTESIAN coordinate system with Deck.gl, and that’s why I am modifying this code to return unprojected coordinates in `toUnprojectedJSON` as a test.

So, to provide some context, in our MVTTileLayer PR, they suggested us to use [CARTESIAN coordinate system](https://github.com/uber/deck.gl/blob/master/docs/developer-guide/coordinate-systems.md#supported-coordinate-systems) to avoid projecting and unprojecting points, and use common space positions when rendering our layer.

To support that, they made a PR to support pre-projected positions in Deck.gl which is this one: https://github.com/uber/deck.gl/pull/4140.

So, taking into account those changes, I am changing the code to get MVT points without converting coordinates into WGS84, and get those X, Y points from coordinates’ origin.

I modified `loadGeometry` method and created another one named `getFlatGeometryAndHoles` which returns geometry points from (0,0) taking into account tile index as you can see here: 
https://github.com/mapbox/vector-tile-js/pull/70/files#diff-eb2dc36e72f5c177fb8b5df20dc67768R77-R78

I made a little test with Deck.gl PolygonLayer and it’s not working as expected.

I tried without updating Deck.gl with the latest changes first (because I forgot to update), and the polygons were kinda there but much closer to null island than where they should be.

After updating, I see no geometries.

So there’s something that I’m definitely missing. This PR is very WIP, so try not to be bothered by method names.

Researching a bit more on the library, it uses this function to project the points: https://github.com/CartoDB/vector-tile-js/blob/master/lib/vectortilefeature.js#L137-L145. And it sums the points with the tile coordinate origin.

I guess that I’m not getting that common space positions right :(