### PR TITLE
Return geometry positions in a 512x512 tile

### DIFF
--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -197,7 +197,7 @@ VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
     return result;
 };
 
-VectorTileFeature.prototype.toOffsetsJSON = function() {
+VectorTileFeature.prototype.toTileCoordsJSON = function() {
     // Resize tiles to 512x512 bounding box
     var tileSize = 512;
     var tileExtent = this.extent;
@@ -209,25 +209,27 @@ VectorTileFeature.prototype.toOffsetsJSON = function() {
     };
 
     var type = VectorTileFeature.types[this.type];
-    var geometryOffsets = this.loadGeometry(transformFunction);
+    var tileCoordsGeometry = this.loadGeometry(transformFunction);
     var i;
 
     switch (this.type) {
+        // Points
         case 1:
             var points = [];
-            for (i = 0; i < geometryOffsets.length; i++) {
-                points[i] = geometryOffsets[i][0];
+            for (i = 0; i < tileCoordsGeometry.length; i++) {
+                points[i] = tileCoordsGeometry[i][0];
             }
-            geometryOffsets = points;
+            tileCoordsGeometry = points;
             break;
 
+        // Polygons
         case 3:
-            geometryOffsets = classifyRings(geometryOffsets);
+            tileCoordsGeometry = classifyRings(tileCoordsGeometry);
             break;
     }
 
-    if (geometryOffsets.length === 1) {
-        geometryOffsets = geometryOffsets[0];
+    if (tileCoordsGeometry.length === 1) {
+        tileCoordsGeometry = tileCoordsGeometry[0];
     } else {
         type = 'Multi' + type;
     }
@@ -237,7 +239,7 @@ VectorTileFeature.prototype.toOffsetsJSON = function() {
         properties: this.properties,
         geometry: {
             type: type,
-            coordinates: geometryOffsets
+            coordinates: tileCoordsGeometry
         }
     };
 

--- a/lib/vectortilefeature.js
+++ b/lib/vectortilefeature.js
@@ -38,7 +38,7 @@ function readTag(pbf, feature) {
 
 VectorTileFeature.types = ['Unknown', 'Point', 'LineString', 'Polygon'];
 
-VectorTileFeature.prototype.loadGeometry = function() {
+VectorTileFeature.prototype.loadGeometry = function(transformFunction) {
     var pbf = this._pbf;
     pbf.pos = this._geometry;
 
@@ -67,14 +67,14 @@ VectorTileFeature.prototype.loadGeometry = function() {
                 if (line) lines.push(line);
                 line = [];
             }
-
-            line.push(new Point(x, y));
+            line.push(transformFunction(x, y));
 
         } else if (cmd === 7) {
 
             // Workaround for https://github.com/mapbox/mapnik-vector-tile/issues/90
             if (line) {
-                line.push(line[0].clone()); // closePolygon
+                var firstLine = line[0].clone ? line[0].clone() : line[0].slice();
+                line.push(firstLine); // closePolygon
             }
 
         } else {
@@ -126,11 +126,16 @@ VectorTileFeature.prototype.bbox = function() {
     return [x1, y1, x2, y2];
 };
 
+
 VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
+    var transformFunction = function (x, y) {
+        return new Point(x, y);
+    };
+
     var size = this.extent * Math.pow(2, z),
         x0 = this.extent * x,
         y0 = this.extent * y,
-        coords = this.loadGeometry(),
+        coords = this.loadGeometry(transformFunction),
         type = VectorTileFeature.types[this.type],
         i, j;
 
@@ -190,6 +195,57 @@ VectorTileFeature.prototype.toGeoJSON = function(x, y, z) {
     }
 
     return result;
+};
+
+VectorTileFeature.prototype.toOffsetsJSON = function() {
+    // Resize tiles to 512x512 bounding box
+    var tileSize = 512;
+    var tileExtent = this.extent;
+    var transformFunction = function (x, y) {
+        return [
+            (x/tileExtent) * tileSize,
+            (y/tileExtent) * tileSize
+        ];
+    };
+
+    var type = VectorTileFeature.types[this.type];
+    var geometryOffsets = this.loadGeometry(transformFunction);
+    var i;
+
+    switch (this.type) {
+        case 1:
+            var points = [];
+            for (i = 0; i < geometryOffsets.length; i++) {
+                points[i] = geometryOffsets[i][0];
+            }
+            geometryOffsets = points;
+            break;
+
+        case 3:
+            geometryOffsets = classifyRings(geometryOffsets);
+            break;
+    }
+
+    if (geometryOffsets.length === 1) {
+        geometryOffsets = geometryOffsets[0];
+    } else {
+        type = 'Multi' + type;
+    }
+
+    var jsonFeature = {
+        type: "Feature",
+        properties: this.properties,
+        geometry: {
+            type: type,
+            coordinates: geometryOffsets
+        }
+    };
+
+    if ('id' in this) {
+        jsonFeature.id = this.id;
+    }
+
+    return jsonFeature;
 };
 
 // classifies an array of rings into polygons with outer rings and holes


### PR DESCRIPTION
Given our needs in https://github.com/uber/deck.gl/pull/3935, I created a new method in this PR to return a GeoJSON-like object with feature positions within a 512x512 bounding box tile as "coordinates".

So, I had to modify `loadGeometry` method behaviour for that transformation from the original tile extent to a 512 extent tile, and then apply almost all operations within toGeoJSON method to be able to get valid geometries to be used by Deck.gl's GeoJSON layer.

And please, help me choosing a name for `toOffsetsJSON` method 😁 